### PR TITLE
Fix thumbnail cursor states and swap persistence on pagination

### DIFF
--- a/modules/components/thumbnail_gallery.py
+++ b/modules/components/thumbnail_gallery.py
@@ -120,6 +120,10 @@ class ThumbnailGallery(tk.Frame):
         self.thumb_images.append(tk_thumb)
         self.thumb_post_map[slot_idx] = post
 
+        candidate_idx = self._thumb_page * self.NUM_THUMBNAILS + slot_idx
+        if 0 <= candidate_idx < len(self._thumb_candidates):
+            self._thumb_candidates[candidate_idx] = post
+
     def disable_clicks(self):
         for lbl in self._thumb_labels:
             lbl.unbind("<Button-1>")


### PR DESCRIPTION
## Summary

- Show busy/watch cursor on thumbnail "..." placeholders while loading
- Preserve busy cursor on still-loading thumbnails even after the main image finishes loading
- Revert to default cursor when a slot resolves to N/A
- Fix swapped thumbnails reverting to originals when paginating away and back (fixes #3)

## Changes

- `_clear_thumb_slots`: Set `cursor="watch"` on "..." placeholder slots
- `enable_clicks`: Only update cursors/bindings on slots with loaded posts, leaving still-loading slots untouched
- `_fetch_thumb_batch`: Set `cursor=""` when applying the N/A placeholder
- `update_slot`: Sync `_thumb_candidates` when a swap occurs so pagination preserves swaps

## Test plan

- [ ] Load an artist with thumbnails — verify "..." placeholders show busy cursor
- [ ] Verify busy cursor persists on unloaded thumbnails after main image loads
- [ ] Verify N/A placeholders show default cursor
- [ ] Swap a thumbnail with the main image, paginate away, paginate back — verify the swap is preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)